### PR TITLE
The API path does not include a sub-path for the version.

### DIFF
--- a/3-in-1-pipeline/scripts/substitute-and-run.sh
+++ b/3-in-1-pipeline/scripts/substitute-and-run.sh
@@ -24,7 +24,7 @@ validate_api_token() {
     response=$(curl -s -w "%{http_code}" -o /dev/null \
         -H "Authorization: Bearer $api_token" \
         -H "Content-Type: application/json" \
-        "$server_url/api/v1/addEvents" \
+        "$server_url/api/addEvents" \
         -d '[]' \
         --connect-timeout 10 \
         --max-time 30)


### PR DESCRIPTION
Through my own testing and comparison with the [documentation](https://community.sentinelone.com/s/article/000006773), I have verified there is no version number in the API path.